### PR TITLE
Update gcc to 14.2 and use some C++23 features

### DIFF
--- a/firmware/inc/tasks.h
+++ b/firmware/inc/tasks.h
@@ -13,10 +13,8 @@
 /// 
 /// 1. Define each task as a subclass of Tasks::Task like this.
 /// A single instance of this class will be created automatically.
-/// @note This declaration uses the "curiously recurring template pattern" (CRTP).
-/// @see https://en.wikipedia.org/wiki/Curiously_recurring_template_pattern
 /// @code
-/// class ExampleTask : public Tasks::Task<ExampleTask>
+/// class ExampleTask : public Tasks::Task
 /// {
 /// public:
 ///     // Task execution interval in microseconds
@@ -75,24 +73,21 @@ inline tasktime_t getCurrentMicros()
 }
 
 /// @brief  Base class for application-defined tasks
-/// @tparam SUB Subclass that is being declared (CRTP)
-template<typename SUB>
 class Task
 {
 public:
     /// @brief If it's time to call execute(), do so
+    /// @param self "this" object with deduced subclass type
     /// @param now Current time
-    void tick(tasktime_t now)
+    void tick(this auto&& self, tasktime_t now)
     {
-        if (now >= timer) {
-            timer = getCurrentMicros() + subclass()->intervalMicros();
-            subclass()->execute();
+        if (now >= self.timer) {
+            self.timer = getCurrentMicros() + self.intervalMicros();
+            self.execute();
         }
     }
 
 private:
-    SUB* subclass() { return static_cast<SUB*>(this); }
-
     /// @brief Keeps track of the next time this task should be executed
     tasktime_t timer = 0;
 };

--- a/firmware/src/Animation.h
+++ b/firmware/src/Animation.h
@@ -66,7 +66,7 @@ protected:
 };
 
 /// @brief @ref tasks::Task to display the currently-running animation, if any
-class AnimationTask : public tasks::Task<AnimationTask>
+class AnimationTask : public tasks::Task
 {
 public:
     unsigned intervalMicros() const { return Animator::framePeriodUs; }

--- a/firmware/src/Makefile
+++ b/firmware/src/Makefile
@@ -18,7 +18,7 @@ VERSION_FILES = ./version.h ./VERSION.txt
 APP_TYPE = BOOT_SRAM
 
 # Compiler settings
-GCC_PATH = "C:\Program Files (x86)\Arm GNU Toolchain arm-none-eabi\13.3 rel1\bin"
+GCC_PATH = "C:\Program Files (x86)\Arm GNU Toolchain arm-none-eabi\14.2 rel1\bin"
 CPP_STANDARD = -std=gnu++23
 OPT = -O3
 C_INCLUDES = -I../inc

--- a/firmware/src/MiscTasks.h
+++ b/firmware/src/MiscTasks.h
@@ -3,7 +3,7 @@
 #include "tasks.h"
 
 /// @brief @ref tasks::Task that blinks the on-board LED
-class BlinkTask : public tasks::Task<BlinkTask>
+class BlinkTask : public tasks::Task
 {
 public:
     unsigned intervalMicros() const { return 500'000; }
@@ -18,7 +18,7 @@ private:
 
 /// @brief @ref tasks::Task that shows the state of the pushbutton using the
 /// on-board LED
-class ButtonLedTask : public tasks::Task<ButtonLedTask>
+class ButtonLedTask : public tasks::Task
 {
 public:
     unsigned intervalMicros() const { return 50'000; }
@@ -30,7 +30,7 @@ public:
 
 /// @brief @ref tasks::Task that shows the state of the CV1 gate input using the
 /// on-board LED and serial output
-class GateLedTask : public tasks::Task<GateLedTask>
+class GateLedTask : public tasks::Task
 {
 public:
     unsigned intervalMicros() const { return 2'000; }
@@ -49,7 +49,7 @@ public:
 
 /// @brief @ref tasks::Task that prints (via serial output) ADC values from the
 /// CV inputs
-class AdcOutputTask : public tasks::Task<AdcOutputTask>
+class AdcOutputTask : public tasks::Task
 {
 public:
     unsigned intervalMicros() const { return 500'000; }
@@ -99,7 +99,7 @@ private:
 
 /// @brief @ref tasks::Task that prints (via serial output) ADC values to help
 /// with CV input calibration
-class AdcCalibrateTask : public tasks::Task<AdcCalibrateTask>
+class AdcCalibrateTask : public tasks::Task
 {
 public:
     unsigned intervalMicros() const { return 1'500'000; }
@@ -126,7 +126,7 @@ protected:
 };
 
 /// @brief @ref tasks::Task that prints (via serial output) the audio sample rate
-class SampleRateTask : public tasks::Task<SampleRateTask>
+class SampleRateTask : public tasks::Task
 {
 public:
     unsigned intervalMicros() const { return 1'000'000; }

--- a/firmware/src/ProgBitcrush.h
+++ b/firmware/src/ProgBitcrush.h
@@ -137,7 +137,7 @@ public:
 
     /// @brief @ref tasks::Task that prints (via serial output) the bit depth
     /// and sample rate
-    class DebugTask : public tasks::Task<DebugTask>
+    class DebugTask : public tasks::Task
     {
     public:
         unsigned intervalMicros() const { return 1'000'000; }

--- a/firmware/src/ProgDelay.h
+++ b/firmware/src/ProgDelay.h
@@ -299,7 +299,7 @@ public:
 
     /// @brief @ref tasks::Task that prints (via serial output) current
     /// parameter values
-    class DebugTask : public tasks::Task<DebugTask>
+    class DebugTask : public tasks::Task
     {
     public:
         unsigned intervalMicros() const { return 1'000'000; }

--- a/firmware/src/ProgReverb.h
+++ b/firmware/src/ProgReverb.h
@@ -119,7 +119,7 @@ public:
     friend class DebugTask;
 
     /// @brief @ref tasks::Task that prints some info (via serial output)
-    class DebugTask : public tasks::Task<DebugTask>
+    class DebugTask : public tasks::Task
     {
     public:
         unsigned intervalMicros() const { return 1'000'000; }

--- a/firmware/src/ProgSynthDrums.h
+++ b/firmware/src/ProgSynthDrums.h
@@ -189,7 +189,7 @@ public:
     friend class DebugTask;
 
     /// @brief @ref tasks::Task that prints some info (via serial output)
-    class DebugTask : public tasks::Task<DebugTask>
+    class DebugTask : public tasks::Task
     {
     public:
         unsigned intervalMicros() const { return 1'000'000; }

--- a/firmware/src/UITask.h
+++ b/firmware/src/UITask.h
@@ -123,8 +123,9 @@ protected:
         if (HW::button.IsOn() != buttonSaved) {
             return true;
         }
+        static constexpr int minChange = 100;
         int diff = int(HW::CVIn::GetRaw(HW::CVIn::Pot)) - int(potSaved);
-        if (std::abs(diff) > 100) {
+        if (std::abs(diff) > minChange) {
             return true;
         }
         return false;
@@ -168,7 +169,7 @@ public:
         // KLUDGE: A short delay may be required here to keep from immediately
         // exiting Warmup state if there isn't enough time for the ADC to get
         // going before now.
-        //HW::Sys::Delay(10);
+        HW::Sys::Delay(10);
         UI::saveButtonPotValue();
     }
 

--- a/firmware/src/UITask.h
+++ b/firmware/src/UITask.h
@@ -44,7 +44,7 @@ public:
     }
 
     /// @brief User interface task
-    class Task : public tasks::Task<Task>
+    class Task : public tasks::Task
     {
     public:
         unsigned intervalMicros() const { return 50'000; }


### PR DESCRIPTION
Use 14.2 of the gcc compiler.
Use C++23 "deducing this" feature to simplify declarations of Task subclasses.